### PR TITLE
Include support for showing translations in article page

### DIFF
--- a/templates/article_stub.html
+++ b/templates/article_stub.html
@@ -9,6 +9,11 @@
                 </h2>
                 {% endif %}
 
+		{% if not articles_page %}
+		{% include "translations.html" %}
+		{% endif %}                
+                
+
                 {{ article.content }}
                 <div class="clear"></div>
 

--- a/templates/translations.html
+++ b/templates/translations.html
@@ -1,0 +1,6 @@
+{% if article.translations %}
+Translations: 
+    {% for translation in article.translations %}
+        <a href="{{ SITEURL }}/{{ translation.save_as }}">{{ translation.lang }}</a>
+    {% endfor %}
+{% endif %}

--- a/templates/translations.html
+++ b/templates/translations.html
@@ -1,6 +1,6 @@
 {% if article.translations %}
 Translations: 
     {% for translation in article.translations %}
-        <a href="{{ SITEURL }}/{{ translation.save_as }}">{{ translation.lang }}</a>
+        <a href="{{ SITEURL }}/{{ translation.url }}">{{ translation.lang }}</a>
     {% endfor %}
 {% endif %}


### PR DESCRIPTION
This PR adds option to show article translations on the article page.

Sample output can be checked at http://iranzo.github.io/blog/2008/04/20/Logical-volume-manager-LVM/index.html 'Translations' appears under article title
