### PR TITLE
PAGINATION_PATTERNS default value [fix bug]

### DIFF
--- a/templates/pagination.html
+++ b/templates/pagination.html
@@ -3,7 +3,7 @@
 
                 <div class="clear"></div>
                 <div class="pages">
-	{% if PAGINATION_PATTERNS %}
+	{% if PAGINATION_PATTERNS[0][0] != 0 %}
                 {%- if articles_page.has_previous() %}
                 {%   if articles_page.previous_page_number() == 1 %}
 


### PR DESCRIPTION
When `PAGINATION_PATTERNS` is not explicitly set in configuration, the default value is `[PaginationRule(min_page=0, URL=u'{name}{number}{extension}', SAVE_AS=u'{name}{number}{extension}')]` instead of `null`. As a result pagination feature would malfunction because `if PAGINATION_PATTERNS` is always `True`.

By tweaking the if-condition this way the issue is resolved.