### PR TITLE
adapt for small screen sizes

### DIFF
--- a/static/css/screen.css
+++ b/static/css/screen.css
@@ -65,7 +65,6 @@ body {
 
 header, #wrapper {
     padding: 0 10px;
-    min-width: 500px;
     max-width: 910px;
     margin: auto;
 }
@@ -95,6 +94,9 @@ h1, h2, h3 {
 
 img, p, .post > .highlight, .highlighttable, h4, h5, h6 {
     margin-top: 1.2em;
+}
+img + em {
+    font-size: .8em;
 }
 
 blockquote {
@@ -340,3 +342,34 @@ footer p { margin: 0; }
 .right { float: right; }
 
 .clear { clear: both; }
+
+@media screen and (max-width: 1024px) {
+    #wrapper {
+        margin-left: 2.6em;
+        padding:1em;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    #wrapper {
+        margin: 0;
+        padding: 1em;
+    }
+    .date {
+        width: 100%;
+        margin: 0 0 .5em 0;
+    }
+    .post {
+        margin: 0 0 4.5em 0;
+    }
+    .post pre,
+    .post code {
+        white-space: pre-wrap;
+    }
+    .archives {
+        margin: 0 0 1.5em 0 !important;
+    }
+    nav ul {
+        margin: 0 0 1em 0;
+    }
+}


### PR DESCRIPTION
I noticed issue #26 and thought I'll offer my changes for small screen sizes upstream.

![blue-penguin-mobile](https://user-images.githubusercontent.com/8349171/51444230-870f4180-1cf5-11e9-9bb4-2a46cf2dbbe9.png)

Things that are opinionated/notable:

* the `<code>` and `<pre>` monospace section will be `whitespace: pre-wrap;`'ed for small screens, see [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space) - my argument is, if you really want to read code on a handheld, it's best to not scroll horizontally with a thumb while reading vertically down a post and tolerate the not ideal presentation for an uninterrupted reading flow.
I think for sections like your radare2 output with long line comments one might decide to individually nowrap.. I haven't looked deeper into [hilite](https://python-markdown.github.io/extensions/code_hilite/#usage) if it's possible to add a conditional class to the standard css_class that nowraps from within markdown. But for now I thought to prioritze reading flow. If you disagree, remove the `.post pre,` line in the media query.

* I removed the min-width on the wrapper. I don't really see a reason for it being there. It was introduced in #10. If this breaks anything I'm sorry.. I checked all views: index/archives/article/tags on widescreen and handheld and didn't notice downsides. 

* will also fold the archive listing on small screensize nicely

* if there are a lot of `MENU_INTERNAL_PAGES` and `MENUITEMS` it might be preferable to "sandwich" them or squeeze them into one horizontal line instead of line-break. I left this untouched beyond some margin

* introduces a little hack how to make nice image captions (`img + em`), happy to separate this out into an extra PR

```
![photo caption]({attach}../images/blue-penguin.jpg)
*Photo by Author. License: CC BY-NC*
```

Shoutout to the little penguins on the Otago Peninsula, NZ :)