### PR TITLE
Make pagination work with any PAGINATION_PATTERN

### DIFF
--- a/templates/pagination.html
+++ b/templates/pagination.html
@@ -3,35 +3,14 @@
 
                 <div class="clear"></div>
                 <div class="pages">
-	{% if PAGINATION_PATTERNS[0][0] != 0 %}
-                {%- if articles_page.has_previous() %}
-                {%   if articles_page.previous_page_number() == 1 %}
 
-                    <a href="{{ SITEURL }}/" class="prev_page">&larr;&nbsp;Previous</a>
-                {%-   else %}
+                {% if articles_page.has_previous() %}
+                    <a href="{{ SITEURL }}/{{ articles_previous_page.url }}" class="prev_page">&larr;&nbsp;Previous</a>
+                {% endif %}
 
-                    <a href="{{ SITEURL }}/page/{{ articles_page.previous_page_number() }}" class="prev_page">&larr;&nbsp;Previous</a>
-                {%-   endif %}
-                {%- endif %}
-                {%- if articles_page.has_next() %}
-
-                    <a href="{{ SITEURL }}/page/{{ articles_page.next_page_number() }}" class="next_page">Next&nbsp;&rarr;</a>
-                {%- endif %}
-    {% else %}
-                {%- if articles_page.has_previous() %}
-                {%   if articles_page.previous_page_number() == 1 %}
-
-                    <a href="{{ SITEURL }}/{{ page_name }}.html" class="prev_page">&larr;&nbsp;Previous</a>
-                {%-   else %}
-
-                    <a href="{{ SITEURL }}/{{ page_name }}{{ articles_page.previous_page_number() }}.html" class="prev_page">&larr;&nbsp;Previous</a>
-                {%-   endif %}
-                {%- endif %}
-                {%- if articles_page.has_next() %}
-
-                    <a href="{{ SITEURL }}/{{ page_name }}{{ articles_page.next_page_number() }}.html" class="next_page">Next&nbsp;&rarr;</a>
-                {%- endif %}
-    {% endif %}
+                {% if articles_page.has_next() %}
+                    <a href="{{ SITEURL }}/{{ articles_next_page.url }}" class="next_page">Next&nbsp;&rarr;</a>
+                {% endif %}
 
                     <span>Page {{ articles_page.number }} of {{ articles_paginator.num_pages }}</span>
                 </div>


### PR DESCRIPTION
Pelican provides `articles_previous_page.url` and `articles_next_page.url` variables so that you don't need to guess the URL of the next/previous page. See here: http://docs.getpelican.com/en/latest/themes.html#index-html

Was there a reason that you try to construct the URL each time? I am not very familiar with Pelican, so you might have thought of a scenario that I didn't :)